### PR TITLE
Add committable Akka source and support for multi-topic consumer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - sudo chmod +x /usr/local/bin/sbt
 
 before_install:
-  - docker run -d -it -p 6650:6650 -p 8080:8080 -v $PWD/data:/pulsar/data apachepulsar/pulsar:2.1.0-incubating bin/pulsar standalone --advertised-address 127.0.0.1
+  - docker run -d -it -p 6650:6650 -p 8080:8080 -v $PWD/data:/pulsar/data apachepulsar/pulsar:2.2.0 bin/pulsar standalone --advertised-address 127.0.0.1
 
 scala:
 - 2.11.12

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ We pass that function into the source method, providing the seek. Note the impor
 
 ```scala
 import com.sksamuel.pulsar4s.akka.streams._
-val pulsarSource = source(consumerFn, MessageId.earliest)
+val pulsarSource = source(consumerFn, Some(MessageId.earliest))
 ```
 
 The materialized value of the source is an instance of `Control` which provides a method called 'close' which can be used to stop consuming messages.
@@ -225,7 +225,7 @@ val outtopic = Topic("persistent://sample/standalone/ns1/out")
 val consumerFn = () => client.consumer(ConsumerConfig(Seq(intopic), Subscription("mysub")))
 val producerFn = () => client.producer(ProducerConfig(outtopic))
 
-val control = source(consumerFn, MessageId.earliest)
+val control = source(consumerFn, Some(MessageId.earliest))
                 .map { consumerMessage => ProducerMessage(consumerMessage.data) }
                 .to(sink(producerFn)).run()
 

--- a/pulsar4s-akka-streams/src/main/scala/com/sksamuel/pulsar4s/akka/streams/PulsarCommittableSourceGraphStage.scala
+++ b/pulsar4s-akka-streams/src/main/scala/com/sksamuel/pulsar4s/akka/streams/PulsarCommittableSourceGraphStage.scala
@@ -1,0 +1,80 @@
+package com.sksamuel.pulsar4s.akka.streams
+
+import akka.Done
+import akka.stream.Attributes
+import akka.stream.Outlet
+import akka.stream.SourceShape
+import akka.stream.stage.AsyncCallback
+import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.GraphStageWithMaterializedValue
+import akka.stream.stage.OutHandler
+import com.sksamuel.exts.Logging
+import com.sksamuel.pulsar4s.Consumer
+import com.sksamuel.pulsar4s.ConsumerMessage
+import com.sksamuel.pulsar4s.MessageId
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.Failure
+import scala.util.Success
+
+trait CommittableMessage[T] {
+  def ack(cumulative: Boolean = false): Future[Done]
+  def message: ConsumerMessage[T]
+}
+
+class PulsarCommittableSourceGraphStage[T](create: () => Consumer[T], seek: Option[MessageId])
+  extends GraphStageWithMaterializedValue[SourceShape[CommittableMessage[T]], Control]
+    with Logging {
+
+  private val out = Outlet[CommittableMessage[T]]("pulsar.out")
+  override def shape: SourceShape[CommittableMessage[T]] = SourceShape(out)
+
+  private class PulsarCommittableSourceLogic(shape: Shape) extends GraphStageLogic(shape) with OutHandler {
+    setHandler(out, this)
+
+    var consumer: Consumer[T] = _
+    var receiveCallback: AsyncCallback[CommittableMessage[T]] = _
+
+    override def preStart(): Unit = {
+      implicit val context: ExecutionContext = super.materializer.executionContext
+      consumer = create()
+      seek foreach consumer.seek
+      receiveCallback = getAsyncCallback(push(out, _))
+    }
+
+    override def onPull(): Unit = {
+      implicit val context: ExecutionContext = super.materializer.executionContext
+      logger.debug("Pull received; asking consumer for message")
+
+      consumer.receiveAsync.onComplete {
+        case Success(msg) =>
+          logger.debug(s"Message received: $msg")
+          receiveCallback.invoke(new CommittableMessage[T] {
+            override def message: ConsumerMessage[T] = msg
+            override def ack(cumulative: Boolean): Future[Done] = {
+              logger.debug(s"Acknowledging message: $msg")
+              val ackFuture = if (cumulative) {
+                consumer.acknowledgeCumulativeAsync(msg.messageId)
+              } else {
+                consumer.acknowledgeAsync(msg.messageId)
+              }
+              ackFuture.map(_ => Done)
+            }
+          })
+        case Failure(e) =>
+          logger.warn("Error when receiving message", e)
+          failStage(e)
+      }
+    }
+  }
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Control) = {
+    val logic = new PulsarCommittableSourceLogic(shape)
+    val control = new Control {
+      override def close(): Unit = logic.completeStage()
+    }
+    (logic, control)
+  }
+}
+

--- a/pulsar4s-akka-streams/src/main/scala/com/sksamuel/pulsar4s/akka/streams/PulsarSourceGraphStage.scala
+++ b/pulsar4s-akka-streams/src/main/scala/com/sksamuel/pulsar4s/akka/streams/PulsarSourceGraphStage.scala
@@ -14,7 +14,7 @@ trait Control extends Closeable {
   def close(): Unit
 }
 
-class PulsarSourceGraphStage[T](create: () => Consumer[T], seek: MessageId)
+class PulsarSourceGraphStage[T](create: () => Consumer[T], seek: Option[MessageId])
   extends GraphStageWithMaterializedValue[SourceShape[ConsumerMessage[T]], Control]
     with Logging {
 
@@ -31,7 +31,7 @@ class PulsarSourceGraphStage[T](create: () => Consumer[T], seek: MessageId)
 
       override def preStart(): Unit = {
         consumer = create()
-        consumer.seek(seek)
+        seek foreach consumer.seek
         callback = getAsyncCallback(msg => push(out, msg))
       }
 

--- a/pulsar4s-akka-streams/src/main/scala/com/sksamuel/pulsar4s/akka/streams/package.scala
+++ b/pulsar4s-akka-streams/src/main/scala/com/sksamuel/pulsar4s/akka/streams/package.scala
@@ -8,9 +8,41 @@ import scala.concurrent.Future
 
 package object streams {
 
-  def source[T](create: () => Consumer[T], seek: MessageId): Source[ConsumerMessage[T], Control] =
+  /**
+   * Create an Akka Streams source for the given [[Consumer]] that produces [[ConsumerMessage]]s and auto-acknowledges.
+   *
+   * @param create a function to create a new [[Consumer]].
+   * @param seek an optional [[MessageId]] to seek to. Note that seeking will not work on multi-topic subscriptions.
+   *             Prefer setting `subscriptionInitialPosition` in `ConsumerConfig` instead if you need to start at the
+   *             earliest or latest offset.
+   * @return the new [[Source]].
+   */
+  def source[T](create: () => Consumer[T], seek: Option[MessageId] = None): Source[ConsumerMessage[T], Control] =
     Source.fromGraph(new PulsarSourceGraphStage(create, seek))
 
+  /**
+   * Create an Akka Streams source for the given [[Consumer]] that produces [[CommittableMessage]]s, which can be
+   * acknowledged individually.
+   *
+   * @param create a function to create a new [[Consumer]].
+   * @param seek an optional [[MessageId]] to seek to. Note that seeking will not work on multi-topic subscriptions.
+   *             Prefer setting `subscriptionInitialPosition` in `ConsumerConfig` instead if you need to start at the
+   *             earliest or latest offset.
+   * @return the new [[Source]].
+   */
+  def committableSource[T](
+    create: () => Consumer[T],
+    seek: Option[MessageId] = None
+  ): Source[CommittableMessage[T], Control] = {
+    Source.fromGraph(new PulsarCommittableSourceGraphStage[T](create, seek))
+  }
+
+  /**
+   * Create an Akka Streams sink from a [[Producer]].
+   *
+   * @param create a function to create a new [[Producer]]
+   * @return the new [[Sink]].
+   */
   def sink[T](create: () => Producer[T]): Sink[ProducerMessage[T], Future[Done]] =
     Sink.fromGraph(new PulsarSinkGraphStage(create))
 }

--- a/pulsar4s-akka-streams/src/test/scala/com/sksamuel/pulsar4s/akka/streams/Example.scala
+++ b/pulsar4s-akka-streams/src/test/scala/com/sksamuel/pulsar4s/akka/streams/Example.scala
@@ -21,7 +21,7 @@ object Example {
   val consumerFn = () => client.consumer(ConsumerConfig(topics = Seq(intopic), subscriptionName = Subscription("mysub")))
   val producerFn = () => client.producer(ProducerConfig(outtopic))
 
-  val control = source(consumerFn, MessageId.earliest)
+  val control = source(consumerFn, Some(MessageId.earliest))
     .map { consumerMessage => ProducerMessage(consumerMessage.data) }
     .to(sink(producerFn)).run()
 

--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/MessageId.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/MessageId.scala
@@ -1,33 +1,35 @@
 package com.sksamuel.pulsar4s
 
-import org.apache.pulsar.client.impl.{MessageIdImpl, TopicMessageIdImpl}
+import org.apache.pulsar.client.impl.TopicMessageIdImpl
 
 import scala.language.implicitConversions
 
-trait MessageId {
-  def bytes: Array[Byte]
+/**
+ * A wrapper for the Java Pulsar client MessageId.
+ *
+ * Unfortunately we have to retain the underlying Java object, since some of the Java APIs assume `TopicMessageIdImpl`
+ * and perform a type cast from `MessageId`, and this type is not possible to create directly via the public Java API.
+ */
+sealed trait MessageId {
+  def underlying: JMessageId
+  def bytes: Array[Byte] = underlying.toByteArray
+  def topic: Option[Topic] = underlying match {
+    case topicMessageId: TopicMessageIdImpl => Some(Topic(topicMessageId.getTopicName))
+    case _ => None
+  }
+  def topicPartition: Option[TopicPartition] = underlying match {
+    case topicMessageId: TopicMessageIdImpl => Some(TopicPartition(topicMessageId.getTopicPartitionName))
+    case _ => None
+  }
 }
+
+private case class Pulsar4sMessageIdImpl(underlying: JMessageId) extends MessageId
 
 object MessageId {
 
   val earliest: MessageId = fromJava(org.apache.pulsar.client.api.MessageId.earliest)
   val latest: MessageId = fromJava(org.apache.pulsar.client.api.MessageId.latest)
 
-  implicit def fromJava(messageId: JMessageId): MessageId = messageId match {
-    case batch: MessageIdImpl => StandardMessageId(batch.getLedgerId, batch.getEntryId, batch.getPartitionIndex, batch.toByteArray)
-    case topic: TopicMessageIdImpl => TopicMessageId(Topic(topic.getTopicName), fromJava(topic.getInnerMessageId))
-    case other => BasicMessageId(other.toByteArray)
-  }
-
-  implicit def toJava(messageId: MessageId): JMessageId = {
-    org.apache.pulsar.client.api.MessageId.fromByteArray(messageId.bytes)
-  }
-}
-
-case class BasicMessageId(bytes: Array[Byte]) extends MessageId
-
-case class StandardMessageId(ledgerId: Long, entryId: Long, partitionIndex: Int, bytes: Array[Byte]) extends MessageId
-
-case class TopicMessageId(topic: Topic, messageId: MessageId) extends MessageId {
-  override def bytes: Array[Byte] = messageId.bytes
+  implicit def fromJava(messageId: JMessageId): MessageId = Pulsar4sMessageIdImpl(messageId)
+  implicit def toJava(messageId: MessageId): JMessageId = messageId.underlying
 }

--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/PulsarClient.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/PulsarClient.scala
@@ -11,6 +11,8 @@ import scala.collection.JavaConverters._
 
 case class Topic(name: String)
 
+case class TopicPartition(name: String)
+
 case class Subscription(name: String)
 
 object Subscription {


### PR DESCRIPTION
Fixes #5 and a few other issues I found while attempting to implement it. Seeking doesn't work on multi-topic sources, so I needed to make that parameter optional when creating Akka streams sources. I also needed to make the pulsar4s `MessageId` wrap the Java implementation, since there are specific types of `MessageId`s that only the Java client can create and that it expects to see in acknowledgements.

There are quite a few breaking changes here but it seemed worth breaking the API considering that some things didn't work before (at least not on the latest version of Pulsar)