### PR TITLE
Prevent NullPointerException when using generated schemas

### DIFF
--- a/pulsar4s-circe/src/main/scala/com/sksamuel/pulsar4s/circe/package.scala
+++ b/pulsar4s-circe/src/main/scala/com/sksamuel/pulsar4s/circe/package.scala
@@ -35,11 +35,10 @@ package object circe {
                                         printer: Json => String = Printer.noSpaces.pretty): Schema[T] = new Schema[T] {
     override def encode(t: T): Array[Byte] = printer(encoder(t)).getBytes(StandardCharsets.UTF_8)
     override def decode(bytes: Array[Byte]): T = io.circe.jawn.decode[T](new String(bytes, StandardCharsets.UTF_8)).right.get
-    override def getSchemaInfo: SchemaInfo = {
-      val info = new SchemaInfo()
-      info.setName(manifest[T].runtimeClass.getCanonicalName)
-      info.setType(SchemaType.JSON)
-      info
-    }
+    override def getSchemaInfo: SchemaInfo =
+      new SchemaInfo()
+        .setName(manifest[T].runtimeClass.getCanonicalName)
+        .setType(SchemaType.JSON)
+        .setSchema(Array(0))
   }
 }

--- a/pulsar4s-circe/src/test/scala/com/sksamuel/pulsar4s/circe/CirceProducerConsumerTest.scala
+++ b/pulsar4s-circe/src/test/scala/com/sksamuel/pulsar4s/circe/CirceProducerConsumerTest.scala
@@ -1,0 +1,31 @@
+package com.sksamuel.pulsar4s.circe
+
+import java.util.UUID
+
+import com.sksamuel.pulsar4s._
+import io.circe.generic.auto._
+import org.scalatest.FunSuite
+import org.scalatest.Matchers
+
+class CirceProducerConsumerTest extends FunSuite with Matchers {
+
+  test("producer and consumer synchronous round trip") {
+
+    val client = PulsarClient("pulsar://localhost:6650")
+    val topic = Topic("persistent://sample/standalone/ns1/test_" + UUID.randomUUID)
+
+    val producer = client.producer[Cafe](ProducerConfig(topic))
+    val cafe = Cafe("le table", Place(1, "Paris"))
+    val messageId = producer.send(cafe)
+    producer.close()
+
+    val consumer = client.consumer[Cafe](ConsumerConfig(topics = Seq(topic), subscriptionName = Subscription.generate))
+    consumer.seek(messageId.get)
+    val msg = consumer.receive
+    msg.get.value shouldBe cafe
+    consumer.close()
+
+    client.close()
+  }
+
+}

--- a/pulsar4s-jackson/src/main/scala/com/sksamuel/pulsar4s/jackson/package.scala
+++ b/pulsar4s-jackson/src/main/scala/com/sksamuel/pulsar4s/jackson/package.scala
@@ -7,11 +7,10 @@ package object jackson {
   implicit def schema[T: Manifest]: Schema[T] = new Schema[T] {
     override def encode(t: T): Array[Byte] = JacksonSupport.mapper.writeValueAsBytes(t)
     override def decode(bytes: Array[Byte]): T = JacksonSupport.mapper.readValue[T](bytes)
-    override def getSchemaInfo: SchemaInfo = {
-      val info = new SchemaInfo()
-      info.setName(manifest[T].runtimeClass.getCanonicalName)
-      info.setType(SchemaType.JSON)
-      info
-    }
+    override def getSchemaInfo: SchemaInfo =
+      new SchemaInfo()
+        .setName(manifest[T].runtimeClass.getCanonicalName)
+        .setType(SchemaType.JSON)
+        .setSchema(Array(0))
   }
 }

--- a/pulsar4s-json4s/src/main/scala/com/sksamuel/pulsar4s/json4s/package.scala
+++ b/pulsar4s-json4s/src/main/scala/com/sksamuel/pulsar4s/json4s/package.scala
@@ -12,11 +12,10 @@ package object json4s {
   implicit def schema[T <: AnyRef : Manifest](implicit serialization: Serialization, formats: Formats): Schema[T] = new Schema[T] {
     override def encode(t: T): Array[Byte] = serialization.write(t).getBytes("UTF-8")
     override def decode(bytes: Array[Byte]): T = serialization.read[T](new String(bytes, "UTF-8"))
-    override def getSchemaInfo: SchemaInfo = {
-      val info = new SchemaInfo()
-      info.setName(manifest[T].runtimeClass.getCanonicalName)
-      info.setType(SchemaType.JSON)
-      info
-    }
+    override def getSchemaInfo: SchemaInfo =
+      new SchemaInfo()
+        .setName(manifest[T].runtimeClass.getCanonicalName)
+        .setType(SchemaType.JSON)
+        .setSchema(Array(0))
   }
 }

--- a/pulsar4s-play-json/src/main/scala/com/sksamuel/pulsar4s/playjson/playjson.scala
+++ b/pulsar4s-play-json/src/main/scala/com/sksamuel/pulsar4s/playjson/playjson.scala
@@ -14,11 +14,10 @@ package object playjson {
   implicit def playSchema[T: Manifest](implicit w: Writes[T], r: Reads[T]): Schema[T] = new Schema[T] {
     override def encode(t: T): Array[Byte] = Json.stringify(Json.toJson(t)(w)).getBytes(Charset.forName("UTF-8"))
     override def decode(bytes: Array[Byte]): T = Json.parse(bytes).as[T]
-    override def getSchemaInfo: SchemaInfo = {
-      val info = new SchemaInfo()
-      info.setName(manifest[T].runtimeClass.getCanonicalName)
-      info.setType(SchemaType.JSON)
-      info
-    }
+    override def getSchemaInfo: SchemaInfo =
+      new SchemaInfo()
+        .setName(manifest[T].runtimeClass.getCanonicalName)
+        .setType(SchemaType.JSON)
+        .setSchema(Array(0))
   }
 }

--- a/pulsar4s-spray-json/src/main/scala/com/sksamuel/pulsar4s/sprayjson/package.scala
+++ b/pulsar4s-spray-json/src/main/scala/com/sksamuel/pulsar4s/sprayjson/package.scala
@@ -15,11 +15,10 @@ package object sprayjson {
   implicit def spraySchema[T: Manifest](implicit w: RootJsonWriter[T], r: RootJsonReader[T]): Schema[T] = new Schema[T] {
     override def encode(t: T): Array[Byte] = w.write(t).compactPrint.getBytes(Charset.forName("UTF-8"))
     override def decode(bytes: Array[Byte]): T = r.read(new String(bytes, "UTF-8").parseJson)
-    override def getSchemaInfo: SchemaInfo = {
-      val info = new SchemaInfo()
-      info.setName(manifest[T].runtimeClass.getCanonicalName)
-      info.setType(SchemaType.JSON)
-      info
-    }
+    override def getSchemaInfo: SchemaInfo =
+      new SchemaInfo()
+        .setName(manifest[T].runtimeClass.getCanonicalName)
+        .setType(SchemaType.JSON)
+        .setSchema(Array(0))
   }
 }


### PR DESCRIPTION
The current implementation of `SchemaInfo` sets the schema data to null by default, which gives me this exception:

```
java.lang.NullPointerException:
   at org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString.copyFrom(ByteString.java:99)
   at org.apache.pulsar.common.api.Commands.getSchema(Commands.java:491)
   at org.apache.pulsar.common.api.Commands.newProducer(Commands.java:520)
   at org.apache.pulsar.client.impl.ProducerImpl.connectionOpened(ProducerImpl.java:915)
   at org.apache.pulsar.client.impl.ConnectionHandler.lambda$grabCnx$0(ConnectionHandler.java:65)
   at java.util.concurrent.CompletableFuture.uniAccept(CompletableFuture.java:656)
   at java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:632)
   at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474)
   at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:1962)
   at org.apache.pulsar.client.impl.BinaryProtoLookupService.lambda$null$2(BinaryProtoLookupService.java:136)
```

I'm pretty sure it's up to our schema to decide how to use (or not use) this field, so it's not a great API, but it seems reasonable to work around by putting a dummy value there.