### PR TITLE
Valid Schema using circe on Pulsar registry

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,8 @@ lazy val circe = Project("pulsar4s-circe", file("pulsar4s-circe"))
   .settings(libraryDependencies ++= Seq(
     "io.circe" %% "circe-core"     % CirceVersion,
     "io.circe" %% "circe-generic"  % CirceVersion,
-    "io.circe" %% "circe-parser"   % CirceVersion
+    "io.circe" %% "circe-parser"   % CirceVersion,
+    "com.sksamuel.avro4s" %% "avro4s-core" % Avro4sVersion
   ))
   .dependsOn(core)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,6 +27,7 @@ object Build extends AutoPlugin {
     val Slf4jVersion              = "1.7.25"
     val SprayJsonVersion          = "1.3.5"
     val Java8CompatVersion        = "0.8.0"
+    val Avro4sVersion             = "2.0.2"
   }
 
   import autoImport._


### PR DESCRIPTION
Before everything, thanks a lot for your great work.

As the Schema was not sent on circe binding (Array(0)), the SQL presto bindings were not working. Using your excellent work on avro4s I was able to build a schema compatible version for circe.

Does there is a specific reason why you were not using avro4s here (or just lack of time)?
Does the integration seems good and we move the deps to avro4s to core? Do you need help to integrate it to others binding?

If you validate this kind of patch I'll also write a test of the schema generated.

There is also deps problem to use avro4s 2.0.3 (that's why i'm using 2.0.2) because there is no build for scala 2.11 on repository.
