### PR TITLE
Improve Akka streams Control with helper for safe shutdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - sudo chmod +x /usr/local/bin/sbt
 
 before_install:
-  - docker run -d -it -p 6650:6650 -p 8080:8080 -v $PWD/data:/pulsar/data apachepulsar/pulsar:2.2.1 bin/pulsar standalone --advertised-address 127.0.0.1
+  - docker run -d -it -p 6650:6650 -p 8080:8080 -v $PWD/data:/pulsar/data apachepulsar/pulsar:2.3.0 bin/pulsar standalone --advertised-address 127.0.0.1
 
 scala:
 - 2.11.12

--- a/pulsar4s-akka-streams/src/test/scala/com/sksamuel/pulsar4s/akka/streams/Example.scala
+++ b/pulsar4s-akka-streams/src/test/scala/com/sksamuel/pulsar4s/akka/streams/Example.scala
@@ -26,6 +26,6 @@ object Example {
     .to(sink(producerFn)).run()
 
   Thread.sleep(10000)
-  control.close()
+  control.stop()
 
 }


### PR DESCRIPTION
This provides a mechanism to stop the Source without shutting down the actual Pulsar consumer, which gives us the opportunity to finish processing in-flight messages before finally shutting down the Pulsar source.