### PR TITLE
Add support for generating Avro schemas using avro4s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ esdata
 *.sublime-project
 *.sublime-workspace
 
-data/standalone
-
-.metals
 .bloop
+.metals
+
+data/

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,7 @@ before_install:
   - docker run -d -it -p 6650:6650 -p 8080:8080 -v $PWD/data:/pulsar/data apachepulsar/pulsar:2.4.0 bin/pulsar standalone --advertised-address 127.0.0.1
 
 scala:
-- 2.11.12
-- 2.12.6
+- 2.12.9
 
 script:
 - sbt clean test

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ lazy val root = Project("pulsar4s", file("."))
     monix,
     jackson,
     circe,
+    avro,
     playjson,
     sprayjson,
     json4s,
@@ -83,6 +84,13 @@ lazy val sprayjson = Project("pulsar4s-spray-json", file("pulsar4s-spray-json"))
   .settings(name := "pulsar4s-spray-json")
   .settings(libraryDependencies ++= Seq(
     "io.spray" %% "spray-json" % SprayJsonVersion
+  ))
+  .dependsOn(core)
+
+lazy val avro = Project("pulsar4s-avro", file("pulsar4s-avro"))
+  .settings(name := "pulsar4s-avro")
+  .settings(libraryDependencies ++= Seq(
+    "com.sksamuel.avro4s" %% "avro4s-core" % Avro4sVersion
   ))
   .dependsOn(core)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -23,7 +23,8 @@ object Build extends AutoPlugin {
     val PulsarVersion             = "2.4.0"
     val ReactiveStreamsVersion    = "1.0.2"
     val Json4sVersion             = "3.6.7"
-    val ScalaVersion              = "2.11.12"
+    val Avro4sVersion             = "3.0.0"
+    val ScalaVersion              = "2.12.9"
     val ScalatestVersion          = "3.0.8"
     val Slf4jVersion              = "1.7.28"
     val SprayJsonVersion          = "1.3.5"
@@ -39,7 +40,7 @@ object Build extends AutoPlugin {
     // appending everything from 'compileonly' to unmanagedClasspath
     unmanagedClasspath in Compile ++= update.value.select(configurationFilter("compileonly")),
     scalaVersion := ScalaVersion,
-    crossScalaVersions := Seq(ScalaVersion, "2.12.8"),
+    crossScalaVersions := Seq(ScalaVersion),
     publishMavenStyle := true,
     resolvers += Resolver.mavenLocal,
     fork in Test := true,

--- a/pulsar4s-avro/src/main/scala/com/sksamuel/pulsar4s/avro/package.scala
+++ b/pulsar4s-avro/src/main/scala/com/sksamuel/pulsar4s/avro/package.scala
@@ -1,0 +1,61 @@
+package com.sksamuel.pulsar4s
+
+import java.io.ByteArrayOutputStream
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+import com.sksamuel.avro4s.AvroSchema
+import com.sksamuel.avro4s.AvroInputStream
+import com.sksamuel.avro4s.AvroOutputStream
+import com.sksamuel.avro4s.Decoder
+import com.sksamuel.avro4s.Encoder
+import com.sksamuel.avro4s.SchemaFor
+import org.apache.pulsar.client.api.Schema
+import org.apache.pulsar.common.schema.{SchemaInfo, SchemaType}
+
+import scala.annotation.implicitNotFound
+
+/**
+  * Automatic Schema derivation using avro4s
+  *
+  * == Examples ==
+  *
+  * {{{
+  *  import com.sksamuel.pulsar4s.avro._
+  *
+  *  case class City(id: Int, name: String)
+  *
+  *  producer.send(City(1, "London"))
+  *
+  *  val city: City = consumer.receive
+  *
+  * }}}
+  */
+package object avro {
+
+  @implicitNotFound("No Avro Schema for type ${T} found.")
+  implicit def avroSchema[T: Manifest: SchemaFor: Encoder: Decoder]: Schema[T] = new Schema[T] {
+    val schema = AvroSchema[T]
+
+    override def encode(t: T): Array[Byte] = {
+      val baos = new ByteArrayOutputStream
+      val aos = AvroOutputStream.data[T].to(baos).build(schema)
+      aos.write(t)
+      aos.flush()
+      aos.close()
+      baos.toByteArray()
+    }
+    override def decode(bytes: Array[Byte]): T = {
+      val bais = new ByteArrayInputStream(bytes)
+      val ais = AvroInputStream.data[T].from(bais).build(schema)
+      val first = ais.iterator.next()
+      ais.close()
+      first
+    }
+    override def getSchemaInfo: SchemaInfo =
+      new SchemaInfo()
+        .setName(manifest[T].runtimeClass.getCanonicalName)
+        .setType(SchemaType.AVRO)
+        .setSchema(schema.toString.getBytes(StandardCharsets.UTF_8))
+  }
+}

--- a/pulsar4s-avro/src/test/scala/com/sksamuel/pulsar4s/avro/AvroProducerConsumerTest.scala
+++ b/pulsar4s-avro/src/test/scala/com/sksamuel/pulsar4s/avro/AvroProducerConsumerTest.scala
@@ -1,0 +1,30 @@
+package com.sksamuel.pulsar4s.avro
+
+import java.util.UUID
+
+import com.sksamuel.pulsar4s._
+import org.scalatest.FunSuite
+import org.scalatest.Matchers
+
+class AvroProducerConsumerTest extends FunSuite with Matchers {
+
+  test("producer and consumer synchronous round trip") {
+
+    val client = PulsarClient("pulsar://localhost:6650")
+    val topic = Topic("persistent://sample/standalone/ns1/test_" + UUID.randomUUID)
+
+    val producer = client.producer[Cafe](ProducerConfig(topic))
+    val cafe = Cafe("le table", Place(1, "Paris"))
+    val messageId = producer.send(cafe)
+    producer.close()
+
+    val consumer = client.consumer[Cafe](ConsumerConfig(topics = Seq(topic), subscriptionName = Subscription.generate))
+    consumer.seek(messageId.get)
+    val msg = consumer.receive
+    msg.get.value shouldBe cafe
+    consumer.close()
+
+    client.close()
+  }
+
+}

--- a/pulsar4s-avro/src/test/scala/com/sksamuel/pulsar4s/avro/CodecDerivationTest.scala
+++ b/pulsar4s-avro/src/test/scala/com/sksamuel/pulsar4s/avro/CodecDerivationTest.scala
@@ -1,0 +1,19 @@
+package com.sksamuel.pulsar4s.avro
+
+import org.scalatest.{Matchers, WordSpec}
+
+case class Place(id: Int, name: String)
+case class Cafe(name: String, place: Place)
+
+class CodecDerivationTest extends WordSpec with Matchers {
+
+  "A derived Schema instance" should {
+
+    "be implicitly found" in {
+      """
+        implicitly[org.apache.pulsar.client.api.Schema[Cafe]]
+      """ should compile
+    }
+  }
+
+}


### PR DESCRIPTION
Fixes #10

Allows automatic generation of Pulsar schemas using the avro4s library. For example:

```scala
import com.sksamuel.pulsar4s.avro._

case class City(id: Int, name: String)
producer.send(City(1, "London"))
val city: City = consumer.receive
```

This automatically generates the Avro schema and provides it in the `SchemaInfo` provided to the Pulsar client. This way Pulsar can validate messages on that topic against the schema.