### PR TITLE
Add useful toString to MessageIds

### DIFF
--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/MessageId.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/MessageId.scala
@@ -13,6 +13,11 @@ import scala.language.implicitConversions
 sealed trait MessageId {
   def underlying: JMessageId
   def bytes: Array[Byte] = underlying.toByteArray
+  def topic: Option[Topic]
+  def topicPartition: Option[TopicPartition]
+}
+
+private case class Pulsar4sMessageIdImpl(underlying: JMessageId) extends MessageId {
   def topic: Option[Topic] = underlying match {
     case topicMessageId: TopicMessageIdImpl => Some(Topic(topicMessageId.getTopicName))
     case _ => None
@@ -21,9 +26,11 @@ sealed trait MessageId {
     case topicMessageId: TopicMessageIdImpl => Some(TopicPartition(topicMessageId.getTopicPartitionName))
     case _ => None
   }
+  override def toString: String = underlying match {
+    case tmi: TopicMessageIdImpl => s"${tmi.getTopicPartitionName} ${tmi.getInnerMessageId}"
+    case mi => mi.toString
+  }
 }
-
-private case class Pulsar4sMessageIdImpl(underlying: JMessageId) extends MessageId
 
 object MessageId {
 


### PR DESCRIPTION
This carries through the toString implementation from the Pulsar Java library, and includes a special toString for multi-topic consumers that includes the topic name.