### PR TITLE
Use Try for ConsumerMessage value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,6 @@ esdata
 
 .bloop
 .metals
+metals.sbt
 
 data/

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ travisBuildNumber in Global := sys.env.getOrElse("TRAVIS_BUILD_NUMBER", "0")
 def travisVersion(v: String, tb: String): String = v.stripSuffix("-SNAPSHOT") + s".$tb-SNAPSHOT"
 
 val org = "com.sksamuel.pulsar4s"
-val AkkaStreamVersion = "2.6.1"
+val AkkaStreamVersion = "2.5.28" // compatible with Akka 2.5.x and 2.6.x
 val CatsEffectVersion = "2.0.0"
 val CirceVersion = "0.12.3"
 val CommonsIoVersion = "2.4"
@@ -15,7 +15,7 @@ val ExtsVersion = "1.61.1"
 val JacksonVersion = "2.9.9"
 val Log4jVersion = "2.12.0"
 val MonixVersion = "3.1.0"
-val PlayJsonVersion = "2.8.1"
+val PlayJsonVersion = "2.7.4" // compatible with 2.7.x and 2.8.x
 val PulsarVersion = "2.4.2"
 val ReactiveStreamsVersion = "1.0.2"
 val Json4sVersion = "3.6.7"

--- a/pulsar4s-circe/src/test/scala/com/sksamuel/pulsar4s/circe/CirceProducerConsumerTest.scala
+++ b/pulsar4s-circe/src/test/scala/com/sksamuel/pulsar4s/circe/CirceProducerConsumerTest.scala
@@ -4,8 +4,12 @@ import java.util.UUID
 
 import com.sksamuel.pulsar4s._
 import io.circe.generic.auto._
+import io.circe.CursorOp.DownField
+import io.circe.DecodingFailure
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Failure
 
 class CirceProducerConsumerTest extends AnyFunSuite with Matchers {
 
@@ -23,6 +27,24 @@ class CirceProducerConsumerTest extends AnyFunSuite with Matchers {
     consumer.seek(messageId.get)
     val msg = consumer.receive
     msg.get.value shouldBe cafe
+    consumer.close()
+
+    client.close()
+  }
+
+  test("producer and consumer synchronous round trip with failed deserialization") {
+
+    val client = PulsarClient("pulsar://localhost:6650")
+    val topic = Topic("persistent://sample/standalone/ns1/test_" + UUID.randomUUID)
+
+    val producer = client.producer[String](ProducerConfig(topic))
+    val messageId = producer.send("""{"foo": "bar"}""")
+    producer.close()
+
+    val consumer = client.consumer[Cafe](ConsumerConfig(topics = Seq(topic), subscriptionName = Subscription.generate))
+    consumer.seek(messageId.get)
+    val msg = consumer.receive
+    msg.get.valueTry shouldBe Failure(DecodingFailure("Attempt to decode value on failed cursor", List(DownField("name"))))
     consumer.close()
 
     client.close()

--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/AsyncHandler.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/AsyncHandler.scala
@@ -4,7 +4,7 @@ import org.apache.pulsar.client.api
 import org.apache.pulsar.client.api.TypedMessageBuilder
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.language.{higherKinds, implicitConversions}
+import scala.language.higherKinds
 import scala.util.Try
 
 trait AsyncHandler[F[_]] {

--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/Consumer.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/Consumer.scala
@@ -7,7 +7,7 @@ import com.sksamuel.exts.Logging
 import org.apache.pulsar.client.api.ConsumerStats
 
 import scala.concurrent.duration.FiniteDuration
-import scala.language.{higherKinds, implicitConversions}
+import scala.language.higherKinds
 import scala.util.Try
 
 trait Consumer[T] extends Closeable {

--- a/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/Producer.scala
+++ b/pulsar4s-core/src/main/scala/com/sksamuel/pulsar4s/Producer.scala
@@ -5,7 +5,7 @@ import java.io.Closeable
 import com.sksamuel.exts.Logging
 import org.apache.pulsar.client.api.{ProducerStats, TypedMessageBuilder}
 
-import scala.language.{higherKinds, implicitConversions}
+import scala.language.higherKinds
 import scala.util.Try
 
 trait Producer[T] extends Closeable with Logging {

--- a/pulsar4s-zio/src/main/scala/com/sksamuel/pulsar4s/zio/ZioAsyncHandler.scala
+++ b/pulsar4s-zio/src/main/scala/com/sksamuel/pulsar4s/zio/ZioAsyncHandler.scala
@@ -9,7 +9,6 @@ import org.apache.pulsar.client.api.ProducerBuilder
 import zio.interop.javaz._
 import zio.{Task, UIO}
 
-import scala.language.implicitConversions
 import scala.util.Try
 
 class ZioAsyncHandler extends AsyncHandler[Task] {


### PR DESCRIPTION
Allow `ConsumerMessage` instances to be able to represent a Pulsar message whose value cannot be parsed. This brings the behavior roughly in line with the Java client, which will allow you to create messages with invalid data but will throw when `getValue` is called. It also prevents the Akka streams source from failing immediately upon creating the `ConsumerMessage`, allowing the user code to decide how to handle the error.