### PR TITLE
Always use callback to access state of Akka graph stage

### DIFF
--- a/pulsar4s-akka-streams/src/main/scala/com/sksamuel/pulsar4s/akka/streams/PulsarSourceGraphStage.scala
+++ b/pulsar4s-akka-streams/src/main/scala/com/sksamuel/pulsar4s/akka/streams/PulsarSourceGraphStage.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.pulsar4s.akka.streams
 
 import akka.Done
+import akka.annotation.DoNotInherit
 import akka.stream.Attributes
 import akka.stream.Outlet
 import akka.stream.SourceShape
@@ -14,21 +15,44 @@ import com.sksamuel.pulsar4s.ConsumerMessage
 import com.sksamuel.pulsar4s.MessageId
 import org.apache.pulsar.client.api.ConsumerStats
 
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.concurrent.Promise
 import scala.util.Failure
 import scala.util.Success
+import scala.util.Try
 import scala.util.control.NonFatal
 
+/**
+  * Provides operations for controlling the Pulsar Akka streams sources.
+  *
+  * This trait is not meant to be inherited by external code.
+  */
+@DoNotInherit
 trait Control {
 
   /**
-   * Stop producing messages from the Pulsar consumer `Source` without shutting down the consumer.
+   * Complete the source but leave the Pulsar consumer open to receive any unacked messages.
+   *
+   * @return a future completed with `Done` when the stream is completed.
    */
-  def stop(): Unit
+  def complete()(implicit ec: ExecutionContext): Future[Done]
+
+  /**
+   * Complete the source but leave the Pulsar consumer open to receive any unacked messages.
+   */
+  @deprecated("This method is blocking. Use `complete` instead.", "2.7.1")
+  def stop(): Unit = {
+    Await.result(complete()(ExecutionContext.global), Duration.Inf)
+    ()
+  }
 
   /**
    * Shut down the Pulsar consumer, and shut down the `Source` if it is not already shut down.
+   *
+   * @return a future completed with `Done` when the source is shut down and the consumer is closed.
    */
   def shutdown()(implicit ec: ExecutionContext): Future[Done]
 
@@ -37,22 +61,13 @@ trait Control {
    * all consumed messages reach the end of the stream. Failures in stream completion will be propagated.
    */
   def drainAndShutdown[S](streamCompletion: Future[S])(implicit ec: ExecutionContext): Future[S] = {
-    stop()
-    streamCompletion
-      .recoverWith {
-        case e: Throwable =>
-          shutdown()
-            .flatMap(_ => streamCompletion)
-            .recoverWith {
-              case _: Throwable => throw e
-            }
-      }
-      .flatMap { result =>
-        shutdown()
-          .map(_ => result)
-          .recover {
-            case e: Throwable => throw e
-          }
+    complete()
+      .flatMap(_ => streamCompletion)
+      .transformWith { resultTry =>
+        shutdown().transform {
+          case Success(_) => resultTry
+          case Failure(e) => resultTry.flatMap(_ => Failure(e))
+        }
       }
   }
 
@@ -77,13 +92,22 @@ class PulsarSourceGraphStage[T](create: () => Consumer[T], seek: Option[MessageI
       @inline private def consumer: Consumer[T] =
         consumerOpt.getOrElse(throw new IllegalStateException("Consumer not initialized!"))
       private var consumerOpt: Option[Consumer[T]] = None
-      private var callback: AsyncCallback[ConsumerMessage[T]] = _
+      private val receiveCallback: AsyncCallback[Try[ConsumerMessage[T]]] = getAsyncCallback {
+        case Success(msg) =>
+          logger.debug(s"Msg received $msg")
+          push(out, msg)
+          consumer.acknowledge(msg.messageId)
+        case Failure(e) =>
+          logger.warn("Error when receiving message", e)
+          failStage(e)
+      }
+      private val stopped: Promise[Done] = Promise()
+      private val stopCallback: AsyncCallback[Unit] = getAsyncCallback { _ => completeStage() }
 
       override def preStart(): Unit = {
         try {
           consumerOpt = Some(create())
           seek foreach consumer.seek
-          callback = getAsyncCallback(msg => push(out, msg))
         } catch {
           case NonFatal(e) =>
             logger.error("Error creating consumer!", e)
@@ -94,23 +118,21 @@ class PulsarSourceGraphStage[T](create: () => Consumer[T], seek: Option[MessageI
       override def onPull(): Unit = {
         implicit val context: ExecutionContext = super.materializer.executionContext
         logger.debug("Pull received; asking consumer for message")
-        consumer.receiveAsync.onComplete {
-          case Success(msg) =>
-            logger.debug(s"Msg received $msg")
-            callback.invoke(msg)
-            consumer.acknowledge(msg.messageId)
-          case Failure(e) =>
-            logger.warn("Error when receiving message", e)
-            failStage(e)
-        }
+        consumer.receiveAsync.onComplete(receiveCallback.invoke)
       }
 
-      override def stop(): Unit = completeStage()
+      override def postStop(): Unit = stopped.success(Done)
 
-      override def shutdown()(implicit ec: ExecutionContext): Future[Done] = {
-        completeStage()
-        consumerOpt.fold(Future.successful(Done))(_.closeAsync.map(_ => Done))
+      override def complete()(implicit ec: ExecutionContext): Future[Done] = {
+        stopCallback.invoke(())
+        stopped.future
       }
+
+      override def shutdown()(implicit ec: ExecutionContext): Future[Done] =
+        for {
+          _ <- complete()
+          _ <- consumerOpt.fold(Future.successful(()))(_.closeAsync)
+        } yield Done
 
       override def stats: ConsumerStats = consumer.stats
     }

--- a/pulsar4s-akka-streams/src/test/scala/com/sksamuel/pulsar4s/akka/streams/Example.scala
+++ b/pulsar4s-akka-streams/src/test/scala/com/sksamuel/pulsar4s/akka/streams/Example.scala
@@ -4,6 +4,10 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.sksamuel.pulsar4s.ProducerMessage
 
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
 object Example {
 
   import com.sksamuel.pulsar4s.{ConsumerConfig, MessageId, ProducerConfig, PulsarClient, Subscription, Topic}
@@ -25,7 +29,6 @@ object Example {
     .map { consumerMessage => ProducerMessage(consumerMessage.data) }
     .to(sink(producerFn)).run()
 
-  Thread.sleep(10000)
-  control.stop()
+  Await.result(control.shutdown(), 10.seconds)
 
 }

--- a/pulsar4s-akka-streams/src/test/scala/com/sksamuel/pulsar4s/akka/streams/PulsarCommittableSourceTest.scala
+++ b/pulsar4s-akka-streams/src/test/scala/com/sksamuel/pulsar4s/akka/streams/PulsarCommittableSourceTest.scala
@@ -226,7 +226,7 @@ class PulsarCommittableSourceTest extends AnyFunSuite with Matchers {
 
     Future {
       Thread.sleep(1000)
-      control.stop()
+      control.complete()
     }
 
     // unless the control shuts down the consumer, the source would never end, and this future would not complete

--- a/pulsar4s-akka-streams/src/test/scala/com/sksamuel/pulsar4s/akka/streams/PulsarSourceTest.scala
+++ b/pulsar4s-akka-streams/src/test/scala/com/sksamuel/pulsar4s/akka/streams/PulsarSourceTest.scala
@@ -101,7 +101,7 @@ class PulsarSourceTest extends AnyFunSuite with Matchers {
 
     Future {
       Thread.sleep(1000)
-      control.stop()
+      control.complete()
     }
 
     // unless the control shuts down the consumer, the source would never end, and this future would not complete


### PR DESCRIPTION
We're not supposed to be accessing the state of the Akka graph stage outside of a callback, since doing so is not thread safe. This creates callbacks to handle the result of the Pulsar receive and send operations and uses those to modify the state.